### PR TITLE
increase test coverage; eslint-plugin-prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": ["eslint:recommended", "prettier"],
+  "plugins": [ "prettier"],
   "env": {
     "mocha": true,
     "node": true,
@@ -7,6 +8,7 @@
   },
   "parserOptions": { "ecmaVersion": 2018 },
   "rules": {
+    "prettier/prettier": "error",
     "prefer-const": ["error", {"destructuring": "all"}],
     "lines-between-class-members": ["error", "always"],
     "no-console": ["error", { "allow": ["warn", "error", "info"] }],

--- a/lib/dialects/abstract/client.js
+++ b/lib/dialects/abstract/client.js
@@ -18,13 +18,9 @@ class AbstractClient {
     }
   }
 
-  _connect() {
-    return null;
-  }
+  _connect() {}
 
-  _end() {
-    return null;
-  }
+  _end() {}
 }
 
 module.exports = AbstractClient;

--- a/lib/dialects/mysql/tables/parser.js
+++ b/lib/dialects/mysql/tables/parser.js
@@ -46,7 +46,7 @@ exports.indexes = indexes => {
   );
 };
 
-exports.extensionNames = name => {
+exports.constraintNames = name => {
   switch (name) {
     case 'PRIMARY KEY':
       return 'primaryKey';
@@ -54,8 +54,6 @@ exports.extensionNames = name => {
       return 'foreignKey';
     case 'UNIQUE':
       return 'unique';
-    case 'INDEX':
-      return 'index';
     // case 'CHECK':
     //   return 'check';
   }
@@ -105,7 +103,7 @@ exports.constraints = constraints => {
       } else {
         return {
           name: constraint_name,
-          type: exports.extensionNames(constraint_type),
+          type: exports.constraintNames(constraint_type),
           columns: [column_name],
           ..._getForeignKeyProperties(chunk),
         };

--- a/lib/dialects/postgres/tables/parser.js
+++ b/lib/dialects/postgres/tables/parser.js
@@ -6,6 +6,7 @@
  */
 'use strict';
 
+const helpers = require('../../../helpers');
 const EXTENSIONS = require('../constants/extensions');
 
 exports.columns = columns => {
@@ -83,7 +84,10 @@ const _extensionDefinition = (type, definition) => {
 
       return {
         columns,
-        references: { table, columns: referenceColumns },
+        references: {
+          table: helpers.normalizeName(table),
+          columns: referenceColumns,
+        },
         onDelete,
         onUpdate,
         match,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "chai": "^4.2.0",
     "eslint": "^6.3.0",
     "eslint-config-prettier": "^6.3.0",
+    "eslint-plugin-prettier": "^3.1.1",
     "husky": "^3.0.5",
     "lint-staged": "^9.2.5",
     "mocha": "^6.2.0",

--- a/test/common/index.test.js
+++ b/test/common/index.test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Metalize = require('../../lib');
+
+describe('common', () => {
+  it('unsupported dialect', done => {
+    try {
+      new Metalize({ dialect: 'mongodb' });
+    } catch (e) {
+      return done();
+    }
+    throw new Error('error test');
+  });
+});

--- a/test/mysql/index.test.js
+++ b/test/mysql/index.test.js
@@ -9,8 +9,20 @@ const connectionConfig = {
   port: 3306,
 };
 
+const _test = metalize => {
+  it('unsupported sequence reading', async () => {
+    try {
+      await metalize.sequences([]);
+    } catch (e) {
+      return true;
+    }
+    throw new Error('error test');
+  });
+};
+
 helpers.setup({
   dialect: 'mysql',
   connectionConfig,
   schema: connectionConfig.database,
+  onGotAdditionalBlocks: _test,
 });


### PR DESCRIPTION
- increase test coverage
- add **eslint-plugin-prettier**
- add `helpers.nornalizeName(foreignKey.references.table)` for `postgres` dialect